### PR TITLE
visibility on cs-ul-wrapper and font-size on cs-dropdown-button

### DIFF
--- a/src/assets/sass/root.scss
+++ b/src/assets/sass/root.scss
@@ -450,6 +450,7 @@
             left: auto;
             right: 0;
             opacity: 0;
+            visibility: hidden;
             transform: scaleX(0);
             background-color: #fff;
             height: 100vh;
@@ -567,6 +568,7 @@
         &.cs-active {
             .cs-ul-wrapper {
                 opacity: 1;
+                visibility: visible;
                 transform: scaleX(1);
                 transition-delay: 0.2s;
             }
@@ -645,7 +647,7 @@
             border: none;
             background-color: transparent;
             font-family: inherit;
-            font-size: inherit;
+            font-size: clamp(1rem, 2.5vw, 1.5rem);
             cursor: pointer;
             appearance: none;
         }


### PR DESCRIPTION
Hi Ethan,
This small PR addresses two CSS issues:
1) The mobile menu was not being hidden properly. A keyboard user could tab into and through it when not in an active state. Added `visibility: hidden` and `visibility: visible` on cs-ul-wrapper so that it it truly hidden not active / active, thus not being focus-able by tabbing.

2) Font size on `cs-dropdown-button` was not consistent with the rest of the other nav items. `font-size: inherit` was not working as intended. Changed it to a `clamp` with same value as other nav items.

